### PR TITLE
Fix organization link on app footer

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,5 +6,5 @@
 </div>
 
 <div class="rodape text-center">
-  <a href="https://github.com/bti-imd"> <i class="fa fa-github fa-lg" aria-hidden="true"></i> Contribua </a>
+  <a href="https://github.com/discentes-imd"> <i class="fa fa-github fa-lg" aria-hidden="true"></i> Contribua </a>
 </div>


### PR DESCRIPTION
This PR fixes the contribute link on the footer, it was pointing to an invalid organization (https://github.com/bti-imd).
